### PR TITLE
Use max allowance for Uniswap's Swap Router and Super Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf cache out",
-    "build": "forge build --via-ir",
+    "build": "forge build",
     "lint": "pnpm lint:sol && pnpm prettier:check",
     "lint:sol": "forge fmt --check && pnpm solhint {script,src,test}/**/*.sol",
     "prettier:check": "prettier --check **/*.{json,md,yml} --ignore-path=.prettierignore",
     "prettier:write": "prettier --write **/*.{json,md,yml} --ignore-path=.prettierignore",
-    "test": "forge test --via-ir",
+    "test": "forge test",
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage"
   },


### PR DESCRIPTION
**Why?**
There's currently 3 allowance calls being made:
* allowance to Uniswap's swap router
* reset of allowance to Uniswap's swap router
* allowance to Super Token

We could remove these repeated semi-expensive calls by using max allowance.

**How?**
When interacting with a particular TOREX the first time: 
* we set max allowance to Uniswap's swap router
* set max allowance to Super Token being upgraded

We can do this because the contract is not supposed to hold any funds. Any funds accidentally sent to the contract are to be transferred out during the next liquidity movement anyway.

**Security**
It's technically possible that either the swap router is malicious, or the super token. Neither of these scenarios would be able to exploit anything. Again, the contract is not supposed to hold any funds outside the atomic liquidity movement transaction.